### PR TITLE
fix: run  animation after add step

### DIFF
--- a/src/views/apps/Animate.vue
+++ b/src/views/apps/Animate.vue
@@ -758,6 +758,7 @@ export default {
 			this.backdoor++;
 			this.addingStep = false;
 			this.animationPaused = false;
+			this.currentStep.left = '0.0%';
 
 			// If it's already playing
 			if(this.animationPlaying){

--- a/src/views/apps/Animate.vue
+++ b/src/views/apps/Animate.vue
@@ -758,7 +758,8 @@ export default {
 			this.backdoor++;
 			this.addingStep = false;
 			this.animationPaused = false;
-			this.currentStep.left = '0.0%';
+			this.currentStep.left = Object.keys(this.keyframes)[0];
+
 
 			// If it's already playing
 			if(this.animationPlaying){


### PR DESCRIPTION
if I add a 99% or other step, click `Play` immediately. It won't play the animation because the `currentStep.left` is 99%.